### PR TITLE
Ensure set_projection returns sp object if given one as input

### DIFF
--- a/R/set_projection.R
+++ b/R/set_projection.R
@@ -132,6 +132,10 @@ set_projection <- function(shp, projection=NA, current.projection=NA, overwrite.
 		}
 	}
 
+	if (is_sp && inherits(shp, "sf") ) {
+	    shp <- as(shp,"Spatial")
+	}
+
 	shp
 
 	#if (is_sp && !is_sp_raster) as(shp, cls) else shp


### PR DESCRIPTION
It seems that set_projection() sometimes returns an sf class object even when an sp class object is passed to it. This causes some functions to fail when they then pass the output of set_projection to a function that expects an sp class object. This seems to be the issue with the smooth_map function and #10.